### PR TITLE
Fix framework-specific repo enablement

### DIFF
--- a/update-server-repo-setup/enable-rmt-repos
+++ b/update-server-repo-setup/enable-rmt-repos
@@ -95,7 +95,7 @@ elif os.path.exists('/usr/bin/gcemetadata'):
 
 for product_id, product_info in mirror_info.items():
     enable_framework = product_info.get('framework')
-    if not framework or framework == enable_framework:
+    if not enable_framework or framework == enable_framework:
         if args.verbose:
             log.write('Enable product with id "%s"\n' % product_id)
             log.write('\t%s\n' % product_info.get('description'))

--- a/update-server-repo-setup/enable-rmt-repos.spec
+++ b/update-server-repo-setup/enable-rmt-repos.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           enable-rmt-repos
-Version:        2.0.0
+Version:        2.0.1
 Release:        0
 Summary:        RMT repository enablement
 License:        GPL-3.0+


### PR DESCRIPTION
Currently the script enables everything when the framework cannot be detected, but when it can -- it enables repos only for that framework.