### PR TITLE
Change the data format of the config file

### DIFF
--- a/update-server-repo-setup/enable-rmt-repos
+++ b/update-server-repo-setup/enable-rmt-repos
@@ -93,14 +93,15 @@ elif os.path.exists('/usr/bin/azuremetadata'):
 elif os.path.exists('/usr/bin/gcemetadata'):
     framework = 'gce'
 
-for product_id, product_info in mirror_info.items():
-    enable_framework = product_info.get('framework')
-    if not enable_framework or framework == enable_framework:
-        if args.verbose:
-            log.write('Enable product with id "%s"\n' % product_id)
-            log.write('\t%s\n' % product_info.get('description'))
-        if not args.dry_run:
-            os.system('rmt-cli repos enable %s' % product_id)    
+for entry in mirror_info:
+    for product_id, product_info in entry.items():
+        enable_framework = product_info.get('framework')
+        if not enable_framework or framework == enable_framework:
+            if args.verbose:
+                log.write('Enable product with id "%s"\n' % product_id)
+                log.write('\t%s\n' % product_info.get('description'))
+            if not args.dry_run:
+                os.system('rmt-cli repos enable %s' % product_id)    
 
 if args.log_file:
     log.close()

--- a/update-server-repo-setup/enable-rmt-repos
+++ b/update-server-repo-setup/enable-rmt-repos
@@ -93,15 +93,19 @@ elif os.path.exists('/usr/bin/azuremetadata'):
 elif os.path.exists('/usr/bin/gcemetadata'):
     framework = 'gce'
 
+all_repo_ids = []
 for entry in mirror_info:
-    for product_id, product_info in entry.items():
-        enable_framework = product_info.get('framework')
+    for repository_id, repository_info in entry.items():
+        enable_framework = repository_info.get('framework')
         if not enable_framework or framework == enable_framework:
             if args.verbose:
-                log.write('Enable product with id "%s"\n' % product_id)
-                log.write('\t%s\n' % product_info.get('description'))
+                log.write('Enable repository with id "%s"\n' % repository_id)
+                log.write('\t%s\n' % repository_info.get('description'))
             if not args.dry_run:
-                os.system('rmt-cli repos enable %s' % product_id)    
+                all_repo_ids.append(repository_id)
+
+if all_repo_ids:
+    os.system('rmt-cli repos enable %s' % ' '.join(all_repo_ids))
 
 if args.log_file:
     log.close()

--- a/update-server-repo-setup/enable-rmt-repos.spec
+++ b/update-server-repo-setup/enable-rmt-repos.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           enable-rmt-repos
-Version:        2.0.1
+Version:        3.0.0
 Release:        0
 Summary:        RMT repository enablement
 License:        GPL-3.0+

--- a/update-server-repo-setup/enable-rmt-repos.spec
+++ b/update-server-repo-setup/enable-rmt-repos.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           enable-rmt-repos
-Version:        3.0.0
+Version:        3.0.1
 Release:        0
 Summary:        RMT repository enablement
 License:        GPL-3.0+

--- a/update-server-repo-setup/generate-repos-config
+++ b/update-server-repo-setup/generate-repos-config
@@ -50,7 +50,7 @@ class RepoConfigGenerator:
         config_json = open(self.product_config_file, 'r').read()
         config = json.loads(config_json)
 
-        products = {}
+        products = []
         consistency_err_msg = 'No %s specified for config with comment "%s"'
         for item in config:
             comment = item.get('comment')
@@ -89,12 +89,14 @@ class RepoConfigGenerator:
                         triplet = (
                             '%s/%s/%s' % (identifier, version, arch)
                         ).lower()
-                        
-                        products[triplet] = {
-                            'additional_repos': item.get('additional_repos'),
-                            'exclusions': item.get('exclusions'),
-                            'framework': framework
-                        }
+                        products.append({
+                            triplet: {
+                                'additional_repos':
+                                item.get('additional_repos'),
+                                'exclusions': item.get('exclusions'),
+                                'framework': framework
+                            }
+                        })
         
         return products
 
@@ -144,42 +146,48 @@ class RepoConfigGenerator:
         config_products = self.make_products_list()
         scc_products = self.get_scc_products()
         
-        result = {}
-        for triplet, product_settings in config_products.items():
-            exclusions = product_settings.get('exclusions')
-            scc_product = scc_products.get(triplet)
-            if not scc_product:
-                msg = 'WARNING: Configured product "%s" not provided by SCC. '
-                msg += 'Skipping product.'
-                print(msg % triplet)
-                continue
-            
-            for repo in scc_product:
-                fs_location = repo['url'].split('suse.com')[-1]
-                repo_name = repo['name']
-                skip = False
-                if (repo['enabled']):
-                    if self._add_repo(repo_name, exclusions):
-                        if self.verbose:
-                            print('Adding mandatory repo "%s"' % repo_name)
-                        result[repo['id']] = {
-                            'description': repo['description'],
-                            'framework': product_settings['framework'],
-                            'location': fs_location
-                        }
-                else:
-                    additional_repos = product_settings['additional_repos']
-                    for additional_repo in additional_repos:
+        result = []
+        for config_product in config_products:
+            for triplet, product_settings in config_product.items():
+                exclusions = product_settings.get('exclusions')
+                framework = product_settings['framework']
+                scc_product = scc_products.get(triplet)
+                if not scc_product:
+                    msg = 'WARNING: Configured product "%s" not provided '
+                    msg += 'by SCC. Skipping product.'
+                    print(msg % triplet)
+                    continue
+                
+                for repo in scc_product:
+                    fs_location = repo['url'].split('suse.com')[-1]
+                    repo_name = repo['name']
+                    skip = False
+                    if (repo['enabled']):
                         if self._add_repo(repo_name, exclusions):
-                            if additional_repo in repo_name:
-                                if self.verbose:
-                                    msg = 'Adding additional repo "%s"'
-                                    print(msg % repo_name)
-                                result[repo['id']] = {
+                            if self.verbose:
+                                print('Adding mandatory repo "%s"' % repo_name)
+                            result.append({
+                                repo['id']: {
                                     'description': repo['description'],
-                                    'framework': product_settings['framework'],
+                                    'framework': framework,
                                     'location': fs_location
                                 }
+                            })
+                    else:
+                        additional_repos = product_settings['additional_repos']
+                        for additional_repo in additional_repos:
+                            if self._add_repo(repo_name, exclusions):
+                                if additional_repo in repo_name:
+                                    if self.verbose:
+                                        msg = 'Adding additional repo "%s"'
+                                        print(msg % repo_name)
+                                    result.append({
+                                        repo['id']: {
+                                            'description': repo['description'],
+                                            'framework': framework,
+                                            'location': fs_location
+                                        }
+                                    })
         
         return result
 


### PR DESCRIPTION
In order to support the same repo for multiple frameworks we need to switch from a dict storage model to a list of dicts model. This addresses the issue that we could only either have a repo for one framework or all.
