### PR TITLE
Handle redirector repositories

### DIFF
--- a/update-server-repo-setup/generate-repos-config
+++ b/update-server-repo-setup/generate-repos-config
@@ -159,7 +159,7 @@ class RepoConfigGenerator:
                     continue
                 
                 for repo in scc_product:
-                    fs_location = repo['url'].split('suse.com')[-1]
+                    fs_location = repo['url'].split('.com')[-1]
                     repo_desc = repo['description']
                     if (repo['enabled']):
                         if self._add_repo(repo_desc, exclusions):


### PR DESCRIPTION
It is possible to have repositories that have no local storage but redirect to another repository location. Set the location data for these to None.