### PR TITLE
Filter out repo prefix

### DIFF
--- a/update-server-repo-setup/generate-repos-config
+++ b/update-server-repo-setup/generate-repos-config
@@ -160,6 +160,10 @@ class RepoConfigGenerator:
                 
                 for repo in scc_product:
                     fs_location = repo['url'].split('.com')[-1]
+                    # The "repo" prefix is implied in newer products
+                    # filter it out to be consistent
+                    if fs_location.startswith('/repo'):
+                        fs_location = fs_location[5:]
                     repo_desc = repo['description']
                     if (repo['enabled']):
                         if self._add_repo(repo_desc, exclusions):


### PR DESCRIPTION
Filter out the "repo" path component. Older products that used to be in the Red Carpet Enterprise ($RCE) location have a "repo" component as the url. However, for newer products the "repo" part of the path is implied. Remove the "repo" part of the path to be consistent and make tools higher up the stack work properly.