### PR TITLE
Handle undefined additional repos

### DIFF
--- a/update-server-repo-setup/generate-repos-config
+++ b/update-server-repo-setup/generate-repos-config
@@ -180,7 +180,9 @@ class RepoConfigGenerator:
                                 }
                             )
                     else:
-                        additional_repos = product_settings['additional_repos']
+                        additional_repos = product_settings.get(
+                            'additional_repos', []
+                        )
                         for additional_repo in additional_repos:
                             if self._add_repo(repo_desc, exclusions):
                                 if additional_repo in repo_desc:


### PR DESCRIPTION
It is possible that a product definition in SCC has "none" as the setting for additional repos. This caused and issue as the code expected the value to always be an iterable. This change addresses this problem.