### PR TITLE
Add the origin url for a repo to the config file

### DIFF
--- a/update-server-repo-setup/enable-rmt-repos.spec
+++ b/update-server-repo-setup/enable-rmt-repos.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           enable-rmt-repos
-Version:        4.0.2
+Version:        4.0.3
 Release:        0
 Summary:        RMT repository enablement
 License:        GPL-3.0+

--- a/update-server-repo-setup/generate-repos-config
+++ b/update-server-repo-setup/generate-repos-config
@@ -176,7 +176,8 @@ class RepoConfigGenerator:
                                     'id': repo['id'],
                                     'description': repo_desc,
                                     'framework': framework,
-                                    'location': fs_location
+                                    'location': fs_location,
+                                    'url': repo['url']
                                 }
                             )
                     else:
@@ -194,7 +195,8 @@ class RepoConfigGenerator:
                                             'id': repo['id'],
                                             'description': repo['description'],
                                             'framework': framework,
-                                            'location': fs_location
+                                            'location': fs_location,
+                                            'url': repo['url']
                                         }
                                     )
         


### PR DESCRIPTION
With RMT 2.25 the RMT setup supports the specification of repositories thta should not get mirrored but become pass through. Meaning the RMT server pretends to have the repo mirrored but actually passes the request to an upstream repo to be fulfilled. The rmt-cli tool has no way to identify such repos and therefore there is an issue when we check the consistency on an update server to verify that was is enabled is also mirrored, meaning copied to local disk. By adding the url to the configuration file the consistency checker can use the rmt.conf file and skip domains that are set up as pull through during the verification that the repo is properly mirrored to local disk.